### PR TITLE
Update to newer rollup api

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
   ],
   "devDependencies": {
     "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-rollup": "^1.1.1",
     "babel-register": "^6.4.3",
     "mocha": "^2.4.5",
     "rimraf": "^2.5.1",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "babel-register": "^6.4.3",
     "mocha": "^2.4.5",
     "rimraf": "^2.5.1",
-    "rollup": "^0.21.3",
+    "rollup": "^0.32.4",
     "rollup-plugin-babel": "^2.3.9"
   },
   "scripts": {
@@ -42,6 +42,9 @@
   "homepage": "https://github.com/Swatinem/rollup-plugin-url#readme",
   "dependencies": {
     "mime": "^1.3.4",
-    "rollup-pluginutils": "^1.3.1"
+    "rollup-pluginutils": "^2.0.1"
+  },
+  "peerDependencies": {
+    "rollup": ">=0.32.4"
   }
 }

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -11,10 +11,19 @@ const external = [
 export default {
   entry: "src/index.js",
   external,
-  plugins: [babel({
-    babelrc: false,
-    presets: ["es2015-rollup"],
-  })],
+  plugins: [
+    babel({
+      babelrc: false,
+      "presets": [
+        [
+          "es2015",
+          {
+            "modules": false
+          }
+        ]
+      ],
+    })
+  ],
   format: "cjs",
   dest: "dist/index.js",
 }

--- a/src/index.js
+++ b/src/index.js
@@ -52,13 +52,13 @@ export default function url(options = {}) {
         return `export default "${data}"`
       })
     },
-    write(options) {
+    onwrite: function write(options) {
       const base = path.dirname(options.dest)
       return Promise.all(Object.keys(copies).map(name => {
         const output = copies[name]
         return copy(name, path.join(base, output))
       }))
-    },
+    }
   }
 }
 

--- a/test/index.js
+++ b/test/index.js
@@ -1,7 +1,7 @@
 import assert from "assert"
 import fs from "fs"
 import rimraf from "rimraf"
-import rollup from "rollup"
+import { rollup } from "rollup"
 import url from "../"
 
 const dest = "output/output.js"
@@ -52,12 +52,12 @@ function promise(fn, ...args) {
 
 function run(entry, limit, publicPath = "") {
   const plugin = url({limit, publicPath})
-  return rollup.rollup({
+  return rollup({
     entry,
     plugins: [plugin],
   }).then(bundle => bundle.write({
     dest,
-  })).then(() => plugin.write({dest}))
+  }))
 }
 
 function assertOutput(content) {


### PR DESCRIPTION
From version `0.32.4` rollup provides `onwrite` hook, so there is no more need in `write` plugin method.
What was done:
1. `write` method replaced with `onwrite` (**Incompatible change!**)
2. added `rollup >= 0.32.4` in `peerDependencies`
3. `rollup` updated to `0.32.4` in `devDependencies` for tests
4. updated test to work with newer version of rollup

Also done:
1. removed `babel-preset-es2015-rollup`, see https://github.com/rollup/rollup-plugin-babel\#configuring-babel
2. updated `rollup-pluginutils`