### PR TITLE
fix: change to onwrite hook in case output folder does not exists

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -53,7 +53,7 @@ export default function url(options = {}) {
         return `export default "${data}"`
       })
     },
-    generateBundle: function write(options) {
+    onwrite: function write(options) {
       // Allow skipping saving files for server side builds.
       if (!emitFiles) return
 


### PR DESCRIPTION
Hello!
We are trying to build a project that uses this plugin and we noticed that everything works fine if the `output` folder exists.
When the `output` folder doesn't exists, it throws the following error:
```
[!] (Plugin at pos 4 plugin) Error: ENOENT: no such file or directory, open 'dist/79d68e25caabdde7.gif'
Error: ENOENT: no such file or directory, open 'dist/79d68e25caabdde7.gif'
```
_pos 4 plugin is the url plugin_

I changed the hook to the onwrite hook after checking the rollup code: https://github.com/rollup/rollup/blob/master/src/rollup/index.ts#L410, since the writeOutputFile action that creates the `output` folder it's called after the generateBundle hook.

Let me know if this helps!