### PR TITLE
Added `destDir` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ url({
 ```
 Emitted File: `path/to/image.png`
 
+### destDir
+
+Optional. Type: `string`
+
+The destination dir to copy assets, usually used to rebase the assets according to HTML files.
+
 # License
 
 LGPL-3.0

--- a/src/index.js
+++ b/src/index.js
@@ -70,11 +70,11 @@ export default function url(options = {}) {
         return `export default "${data}"`
       })
     },
-    generateBundle: async function write(options) {
+    generateBundle: async function write(outputOptions) {
       // Allow skipping saving files for server side builds.
       if (!emitFiles) return
 
-      const base = options.dir || path.dirname(options.file)
+      const base = options.destDir || outputOptions.dir || path.dirname(outputOptions.file)
 
       await promise(mkpath, base)
 

--- a/test/index.js
+++ b/test/index.js
@@ -138,6 +138,15 @@ describe("rollup-plugin-url", () => {
       )
   )
 
+  it("should copy the file according to destDir option", () =>
+    run("./fixtures/png.js", { limit: 10, fileName: "[dirname][hash][extname]", destDir: path.join(__dirname, "output/dest") })
+      .then(
+        () => Promise.all([
+          assertExists(`output/dest/fixtures/${pnghash}`)
+        ])
+      )
+  )
+
   it("should create multiple modules and inline files", () => {
     return run(["./fixtures/svg.js", "./fixtures/png.js"], {}, true)
       .then(


### PR DESCRIPTION
Please imagine a situation like this:

*rollup.config.js*
```js
import rollup from 'rollup';
import url from 'rollup-plugin-url';

module.exports = {
	input: 'src/js/index.js',
	output: {
		name: 'example',
		file: 'dist/js/index.js',
		format: 'iife'
	},
	plugins: [
		url({
			fileName: "[dirname][hash][extname]",
			sourceDir: path.join(__dirname, "src")
		})
	]
};
```

*src/js/index.js*
```js
import image from '../img/image.png';
```

File `image.png` will be emitted to `dist/js/img/image.png`, but actually the expectation is to emit the file to `dist/img/image.png`, that's why I created this PR to add `destDir` option, which will be helpful for users on this situation :)