### PR TITLE
Fix [dirname] substitution on Windows

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -54,7 +54,7 @@ export default function url(options = {}) {
           const outputFileName = fileName
             .replace(/\[hash\]/g, hash)
             .replace(/\[extname\]/g, ext)
-            .replace(/\[dirname\]/g, `${relativeDir}${path.sep}`)
+            .replace(/\[dirname\]/g, `${relativeDir}/`)
             .replace(/\[name\]/g, name)
           data = `${publicPath}${outputFileName}`
           copies[id] = outputFileName


### PR DESCRIPTION
This should be the _output_ path, which is a relative Javascript path, not a filesystem path.

As it stands with using `path.sep` windows clients will get output like this:
```js
var fileName = "path/to/the\file.png";
```
This fixes the issue for all clients by hardcoding the `/` character for the `dirname` substitution