### PR TITLE
fix: use fs.mkdir to instead of mkpath as it was not maintained

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
   "homepage": "https://github.com/Swatinem/rollup-plugin-url#readme",
   "dependencies": {
     "mime": "^2.4.4",
-    "mkpath": "^1.0.0",
     "rollup-pluginutils": "^2.8.1"
   },
   "peerDependencies": {

--- a/src/index.js
+++ b/src/index.js
@@ -3,7 +3,6 @@ import mime from "mime"
 import crypto from "crypto"
 import path from "path"
 import fs from "fs"
-import mkpath from "mkpath"
 
 const defaultInclude = [
   "**/*.svg",
@@ -48,7 +47,7 @@ export default function url(options = {}) {
           const relativeDir = options.sourceDir
             ? path.relative(options.sourceDir, path.dirname(id))
             : path.dirname(id).split(path.sep).pop()
-          
+
           // Generate the output file name based on some string
           // replacement parameters
           const outputFileName = fileName
@@ -119,4 +118,9 @@ function encodeSVG(buffer) {
     .replace(/'/gmi, "\\i"))
     // encode brackets
     .replace(/\(/g, "%28").replace(/\)/g, "%29")
+}
+
+// use fs.mkdir to instead of mkpath package, see https://github.com/jrajav/mkpath/issues/6
+function mkpath(path, err) {
+  return fs.mkdir(path, { recursive: true }, err);
 }


### PR DESCRIPTION
see https://github.com/jrajav/mkpath/issues/6

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/rollup/rollup-plugin-url/24)
<!-- Reviewable:end -->
